### PR TITLE
Don't base64 encode third-party caveat vids

### DIFF
--- a/pymacaroons/caveat.py
+++ b/pymacaroons/caveat.py
@@ -1,3 +1,5 @@
+from base64 import standard_b64encode
+
 from pymacaroons.utils import convert_to_string, convert_to_bytes
 
 
@@ -44,6 +46,9 @@ class Caveat(object):
     def to_dict(self):
         return {
             'cid': self.caveat_id,
-            'vid': self.verification_key_id,
+            'vid': (
+                standard_b64encode(self.verification_key_id)
+                if self.verification_key_id else None
+            ),
             'cl': self.location
         }

--- a/pymacaroons/caveat_delegates/third_party.py
+++ b/pymacaroons/caveat_delegates/third_party.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from base64 import standard_b64encode, standard_b64decode
 import binascii
 
 from libnacl.secret import SecretBox
@@ -29,12 +28,14 @@ class ThirdPartyCaveatDelegate(BaseThirdPartyCaveatDelegate):
                                key,
                                key_id,
                                **kwargs):
-        derived_key = truncate_or_pad(generate_derived_key(convert_to_bytes(
-            key)))
+        derived_key = truncate_or_pad(
+            generate_derived_key(convert_to_bytes(key))
+        )
         old_key = truncate_or_pad(binascii.unhexlify(macaroon.signature_bytes))
         box = SecretBox(key=old_key)
-        encrypted = box.encrypt(derived_key, nonce=kwargs.get('nonce'))
-        verification_key_id = standard_b64encode(encrypted)
+        verification_key_id = box.encrypt(
+            derived_key, nonce=kwargs.get('nonce')
+        )
         caveat = Caveat(
             caveat_id=key_id,
             location=location,
@@ -99,8 +100,5 @@ class ThirdPartyCaveatVerifierDelegate(BaseThirdPartyCaveatVerifierDelegate):
     def _extract_caveat_key(self, signature, caveat):
         key = truncate_or_pad(signature)
         box = SecretBox(key=key)
-        decoded_vid = standard_b64decode(
-            caveat._verification_key_id
-        )
-        decrypted = box.decrypt(decoded_vid)
+        decrypted = box.decrypt(caveat._verification_key_id)
         return decrypted

--- a/pymacaroons/serializers/json_serializer.py
+++ b/pymacaroons/serializers/json_serializer.py
@@ -1,5 +1,5 @@
 import json
-
+from base64 import standard_b64decode
 from pymacaroons.utils import convert_to_string
 
 
@@ -24,7 +24,9 @@ class JsonSerializer(object):
         for c in deserialized['caveats']:
             caveat = Caveat(
                 caveat_id=c['cid'],
-                verification_key_id=c['vid'],
+                verification_key_id=(
+                    standard_b64decode(c['vid']) if c['vid'] else None
+                ),
                 location=c['cl']
             )
             caveats.append(caveat)

--- a/tests/functional_tests/functional_tests.py
+++ b/tests/functional_tests/functional_tests.py
@@ -197,7 +197,7 @@ never use the same secret twice'
         m.add_third_party_caveat('http://auth.mybank/', caveat_key, identifier)
         assert_equal(
             m.signature,
-            '6b99edb2ec6d7a4382071d7d41a0bf7dfa27d87d2f9fea86e330d7850ffda2b2'
+            'd27db2fd1f22760e4c3dae8137e2d8fc1df6c0741c18aed4b97256bf78d1f55c'
         )
 
     def test_serializing_macaroon_with_first_and_third_caveats(self):
@@ -250,7 +250,7 @@ never use the same secret twice'
         protected = m.prepare_for_request(discharge)
         assert_equal(
             protected.signature,
-            'b38b26ab29d3724e728427e758cccc16d9d7f3de46d0d811b70b117b05357b9b'
+            '2eb01d0dd2b4475330739140188648cf25dda0425ea9f661f1574ca0a9eac54e'
         )
 
     def test_verify_third_party_caveats(self):


### PR DESCRIPTION
This causes some incompatibility with other macaroon libs.

Keeping this open until I can verify compatibility