### PR TITLE
Remove superfluous upper bound on six version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     include_package_data=True,
     long_description=long_description,
     install_requires=[
-        'six>=1.8.0,<1.9',
+        'six>=1.8.0',
         'libnacl>=1.3.6,<1.4',
     ],
     classifiers=[


### PR DESCRIPTION
I can't tell anything obviously breaking in 1.9.0, so I'm not sure why this is here, but it causes a dep version conflict with another library I'm depending on.