### PR TITLE
Support libnacl 1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     install_requires=[
         'six>=1.8.0',
-        'libnacl>=1.3.6,<1.5',
+        'libnacl>=1.3.6,<1.6',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
It'd be quite helpful if we could have a release with this; we haven't had a release since #21 was fixed, which is awkward because the version of libnacl pinned before that doesn't support the version of libsodium that's in reasonably current OS distributions.