### PR TITLE
Fix wrong sum of a boolean list.

### DIFF
--- a/pymacaroons/caveat_delegates/first_party.py
+++ b/pymacaroons/caveat_delegates/first_party.py
@@ -34,7 +34,7 @@ class FirstPartyCaveatVerifierDelegate(BaseFirstPartyCaveatVerifierDelegate):
 
     def verify_first_party_caveat(self, verifier, caveat, signature):
         predicate = caveat.caveat_id
-        caveat_met = sum(callback(predicate)
+        caveat_met = all(callback(predicate)
                          for callback in verifier.callbacks)
         return caveat_met
 


### PR DESCRIPTION
When using sum the verification will pass always. For example if you evalueate sum([True, False, False]) > 0 will be always true 