### PR TITLE
Add macaroon v2 format.

### DIFF
--- a/pymacaroons/__init__.py
+++ b/pymacaroons/__init__.py
@@ -1,5 +1,7 @@
 from .caveat import Caveat
 from .macaroon import Macaroon
+from .macaroon import MACAROON_V1
+from .macaroon import MACAROON_V2
 from .verifier import Verifier
 
 
@@ -7,6 +9,8 @@ __all__ = [
     'Macaroon',
     'Caveat',
     'Verifier',
+    'MACAROON_V1',
+    'MACAROON_V2'
 ]
 
 

--- a/pymacaroons/caveat.py
+++ b/pymacaroons/caveat.py
@@ -8,13 +8,25 @@ class Caveat(object):
     def __init__(self,
                  caveat_id=None,
                  verification_key_id=None,
-                 location=None):
+                 location=None,
+                 version=None):
+        from pymacaroons.macaroon import MACAROON_V1
         self.caveat_id = caveat_id
         self.verification_key_id = verification_key_id
         self.location = location
+        if version is None:
+            version = MACAROON_V1
+        self._version = version
 
     @property
     def caveat_id(self):
+        from pymacaroons.macaroon import MACAROON_V1
+        if self._version == MACAROON_V1:
+            return convert_to_string(self._caveat_id)
+        return self._caveat_id
+
+    @property
+    def caveat_id_bytes(self):
         return self._caveat_id
 
     @property
@@ -44,8 +56,12 @@ class Caveat(object):
         return self._verification_key_id is not None
 
     def to_dict(self):
+        try:
+            cid = convert_to_string(self.caveat_id)
+        except UnicodeEncodeError:
+            cid = convert_to_string(standard_b64encode(self.caveat_id_bytes))
         return {
-            'cid': self.caveat_id,
+            'cid': cid,
             'vid': (
                 standard_b64encode(self.verification_key_id)
                 if self.verification_key_id else None

--- a/pymacaroons/caveat.py
+++ b/pymacaroons/caveat.py
@@ -15,7 +15,7 @@ class Caveat(object):
 
     @property
     def caveat_id(self):
-        return convert_to_string(self._caveat_id)
+        return self._caveat_id
 
     @property
     def verification_key_id(self):

--- a/pymacaroons/caveat_delegates/encrypted_first_party.py
+++ b/pymacaroons/caveat_delegates/encrypted_first_party.py
@@ -44,7 +44,7 @@ class EncryptedFirstPartyCaveatVerifierDelegate(
         )
 
     def verify_first_party_caveat(self, verifier, caveat, signature):
-        predicate = caveat.caveat_id
+        predicate = caveat.caveat_id_bytes
 
         for signifier, encryptor in iteritems(self.field_encryptors):
             if predicate.startswith(signifier):

--- a/pymacaroons/caveat_delegates/first_party.py
+++ b/pymacaroons/caveat_delegates/first_party.py
@@ -24,7 +24,7 @@ class FirstPartyCaveatDelegate(BaseFirstPartyCaveatDelegate):
         # Check it's valid utf-8 for first party caveats.
         # Will raise a unicode error if not.
         predicate.decode('utf-8')
-        caveat = Caveat(caveat_id=predicate)
+        caveat = Caveat(caveat_id=predicate, version=macaroon.version)
         macaroon.caveats.append(caveat)
         encode_key = binascii.unhexlify(macaroon.signature_bytes)
         macaroon.signature = sign_first_party_caveat(encode_key, predicate)
@@ -46,6 +46,6 @@ class FirstPartyCaveatVerifierDelegate(BaseFirstPartyCaveatVerifierDelegate):
         return binascii.unhexlify(
             sign_first_party_caveat(
                 signature,
-                caveat.caveat_id
+                caveat.caveat_id_bytes
             )
         )

--- a/pymacaroons/caveat_delegates/first_party.py
+++ b/pymacaroons/caveat_delegates/first_party.py
@@ -3,6 +3,7 @@ import binascii
 
 from pymacaroons import Caveat
 from pymacaroons.utils import (
+    convert_to_string,
     convert_to_bytes,
     sign_first_party_caveat
 )
@@ -20,7 +21,10 @@ class FirstPartyCaveatDelegate(BaseFirstPartyCaveatDelegate):
 
     def add_first_party_caveat(self, macaroon, predicate, **kwargs):
         predicate = convert_to_bytes(predicate)
-        caveat = Caveat(caveat_id=convert_to_bytes(predicate))
+        # Check it's valid utf-8 for first party caveats.
+        # Will raise a unicode error if not.
+        predicate.decode('utf-8')
+        caveat = Caveat(caveat_id=predicate)
         macaroon.caveats.append(caveat)
         encode_key = binascii.unhexlify(macaroon.signature_bytes)
         macaroon.signature = sign_first_party_caveat(encode_key, predicate)
@@ -33,7 +37,7 @@ class FirstPartyCaveatVerifierDelegate(BaseFirstPartyCaveatVerifierDelegate):
         super(FirstPartyCaveatVerifierDelegate, self).__init__(*args, **kwargs)
 
     def verify_first_party_caveat(self, verifier, caveat, signature):
-        predicate = caveat.caveat_id
+        predicate = convert_to_string(caveat.caveat_id)
         caveat_met = sum(callback(predicate)
                          for callback in verifier.callbacks)
         return caveat_met
@@ -42,6 +46,6 @@ class FirstPartyCaveatVerifierDelegate(BaseFirstPartyCaveatVerifierDelegate):
         return binascii.unhexlify(
             sign_first_party_caveat(
                 signature,
-                caveat._caveat_id
+                caveat.caveat_id
             )
         )

--- a/pymacaroons/caveat_delegates/third_party.py
+++ b/pymacaroons/caveat_delegates/third_party.py
@@ -39,7 +39,8 @@ class ThirdPartyCaveatDelegate(BaseThirdPartyCaveatDelegate):
         caveat = Caveat(
             caveat_id=key_id,
             location=location,
-            verification_key_id=verification_key_id
+            verification_key_id=verification_key_id,
+            version=macaroon.version
         )
         macaroon.caveats.append(caveat)
         encode_key = binascii.unhexlify(macaroon.signature_bytes)
@@ -85,14 +86,15 @@ class ThirdPartyCaveatVerifierDelegate(BaseThirdPartyCaveatVerifierDelegate):
 
     def _caveat_macaroon(self, caveat, discharge_macaroons):
         # TODO: index discharge macaroons by identifier
-        caveat_macaroon = next((m for m in discharge_macaroons
-                                if m.identifier == caveat.caveat_id), None)
+        caveat_macaroon = next(
+            (m for m in discharge_macaroons
+             if m.identifier_bytes == caveat.caveat_id_bytes), None)
 
         if not caveat_macaroon:
             raise MacaroonUnmetCaveatException(
                 'Caveat not met. '
                 'No discharge macaroon found for identifier: ' +
-                caveat.caveat_id
+                caveat.caveat_id_bytes
             )
 
         return caveat_macaroon

--- a/pymacaroons/field_encryptors/base_field_encryptor.py
+++ b/pymacaroons/field_encryptors/base_field_encryptor.py
@@ -1,4 +1,4 @@
-from pymacaroons.utils import convert_to_bytes, convert_to_string
+from pymacaroons.utils import convert_to_bytes
 
 
 class BaseFieldEncryptor(object):
@@ -9,7 +9,7 @@ class BaseFieldEncryptor(object):
 
     @property
     def signifier(self):
-        return convert_to_string(self._signifier)
+        return convert_to_bytes(self._signifier)
 
     @signifier.setter
     def signifier(self, string_or_bytes):

--- a/pymacaroons/macaroon.py
+++ b/pymacaroons/macaroon.py
@@ -37,7 +37,7 @@ class Macaroon(object):
         self.third_party_caveat_delegate = ThirdPartyCaveatDelegate()
         if key:
             self.signature = create_initial_signature(
-                convert_to_bytes(key), self.identifier
+                convert_to_bytes(key), self.identifier_bytes
             )
 
     @classmethod
@@ -64,6 +64,12 @@ class Macaroon(object):
 
     @property
     def identifier(self):
+        if self.version == MACAROON_V1:
+            return convert_to_string(self._identifier)
+        return self._identifier
+
+    @property
+    def identifier_bytes(self):
         return self._identifier
 
     @identifier.setter
@@ -92,21 +98,18 @@ class Macaroon(object):
     def inspect(self):
         combined = 'location {loc}\n'.format(loc=self.location)
         try:
-            combined += 'identifier {id}\n'.format(id=convert_to_string(
-                self.identifier)
-            )
+            combined += 'identifier {id}\n'.format(id=self.identifier)
         except UnicodeEncodeError:
             combined += 'identifier64 {id}\n'.format(id=convert_to_string(
-                    standard_b64encode(self.identifier)
+                    standard_b64encode(self.identifier_bytes)
             ))
         for caveat in self.caveats:
             try:
-                combined += 'cid {cid}\n'.format(cid=convert_to_string(
-                    caveat.caveat_id
-                ))
+                combined += 'cid {cid}\n'.format(
+                    cid=convert_to_string(caveat.caveat_id))
             except UnicodeEncodeError:
                 combined += 'cid64 {cid}\n'.format(cid=convert_to_string(
-                    standard_b64encode(caveat.caveat_id)
+                    standard_b64encode(caveat.caveat_id_bytes)
                 ))
             if caveat.verification_key_id and caveat.location:
                 vid = convert_to_string(

--- a/pymacaroons/macaroon.py
+++ b/pymacaroons/macaroon.py
@@ -13,6 +13,9 @@ from pymacaroons.utils import (
 from pymacaroons.caveat_delegates import (
     FirstPartyCaveatDelegate, ThirdPartyCaveatDelegate)
 
+MACAROON_V1 = 1
+MACAROON_V2 = 2
+
 
 class Macaroon(object):
 
@@ -21,7 +24,11 @@ class Macaroon(object):
                  identifier=None,
                  key=None,
                  caveats=None,
-                 signature=None):
+                 signature=None,
+                 version=MACAROON_V1):
+        if version > MACAROON_V2:
+            version = MACAROON_V2
+        self._version = version
         self.caveats = caveats or []
         self.location = location or ''
         self.identifier = identifier or ''
@@ -30,12 +37,11 @@ class Macaroon(object):
         self.third_party_caveat_delegate = ThirdPartyCaveatDelegate()
         if key:
             self.signature = create_initial_signature(
-                convert_to_bytes(key), convert_to_bytes(identifier)
+                convert_to_bytes(key), self.identifier
             )
 
     @classmethod
     def deserialize(cls, serialized, serializer=None):
-        serialized = convert_to_string(serialized)
         serializer = serializer or BinarySerializer()
         if serialized:
             return serializer.deserialize(serialized)
@@ -53,8 +59,12 @@ class Macaroon(object):
         self._location = convert_to_bytes(string_or_bytes)
 
     @property
+    def version(self):
+        return self._version
+
+    @property
     def identifier(self):
-        return convert_to_string(self._identifier)
+        return self._identifier
 
     @identifier.setter
     def identifier(self, string_or_bytes):
@@ -81,9 +91,23 @@ class Macaroon(object):
 
     def inspect(self):
         combined = 'location {loc}\n'.format(loc=self.location)
-        combined += 'identifier {id}\n'.format(id=self.identifier)
+        try:
+            combined += 'identifier {id}\n'.format(id=convert_to_string(
+                self.identifier)
+            )
+        except UnicodeEncodeError:
+            combined += 'identifier64 {id}\n'.format(id=convert_to_string(
+                    standard_b64encode(self.identifier)
+            ))
         for caveat in self.caveats:
-            combined += 'cid {cid}\n'.format(cid=caveat.caveat_id)
+            try:
+                combined += 'cid {cid}\n'.format(cid=convert_to_string(
+                    caveat.caveat_id
+                ))
+            except UnicodeEncodeError:
+                combined += 'cid64 {cid}\n'.format(cid=convert_to_string(
+                    standard_b64encode(caveat.caveat_id)
+                ))
             if caveat.verification_key_id and caveat.location:
                 vid = convert_to_string(
                     standard_b64encode(caveat.verification_key_id)
@@ -99,8 +123,16 @@ class Macaroon(object):
     def third_party_caveats(self):
         return [caveat for caveat in self.caveats if caveat.third_party()]
 
-    def prepare_for_request(self, macaroon):
-        protected = macaroon.copy()
+    def prepare_for_request(self, discharge_macaroon):
+        ''' Return a new discharge macaroon bound to the receiving macaroon's
+        current signature so that it can be used in a request.
+
+        This must be done before a discharge macaroon is sent to a server.
+
+        :param discharge_macaroon:
+        :return: bound discharge macaroon
+        '''
+        protected = discharge_macaroon.copy()
         return HashSignaturesBinder(self).bind(protected)
 
     def add_first_party_caveat(self, predicate, **kwargs):

--- a/pymacaroons/serializers/binary_serializer.py
+++ b/pymacaroons/serializers/binary_serializer.py
@@ -1,12 +1,27 @@
 from __future__ import unicode_literals
 
 import binascii
+from collections import namedtuple
+import six
 import struct
-from base64 import urlsafe_b64encode, urlsafe_b64decode
+import sys
+from base64 import urlsafe_b64encode
 
-from pymacaroons.utils import convert_to_bytes
+from pymacaroons.utils import (
+    convert_to_bytes,
+    convert_to_string,
+    raw_b64decode,
+)
 from pymacaroons.serializers.base_serializer import BaseSerializer
 from pymacaroons.exceptions import MacaroonSerializationException
+
+_LOCATION = 1
+_IDENTIFIER = 2
+_VID = 4
+_SIGNATURE = 6
+_EOS = 0
+
+PacketV2 = namedtuple('PacketV2', ['field_type', 'data'])
 
 
 class BinarySerializer(BaseSerializer):
@@ -14,6 +29,16 @@ class BinarySerializer(BaseSerializer):
     PACKET_PREFIX_LENGTH = 4
 
     def serialize(self, macaroon):
+        return urlsafe_b64encode(
+            self.serialize_raw(macaroon)).decode('ascii').rstrip('=')
+
+    def serialize_raw(self, macaroon):
+        from pymacaroons.macaroon import MACAROON_V1
+        if macaroon.version == MACAROON_V1:
+            return self._serialize_v1(macaroon)
+        return self._serialize_v2(macaroon)
+
+    def _serialize_v1(self, macaroon):
         combined = self._packetize(b'location', macaroon.location)
         combined += self._packetize(b'identifier', macaroon.identifier)
 
@@ -29,18 +54,58 @@ class BinarySerializer(BaseSerializer):
             b'signature',
             binascii.unhexlify(macaroon.signature_bytes)
         )
-        return urlsafe_b64encode(combined).decode('ascii').rstrip('=')
+        return combined
+
+    def _serialize_v2(self, macaroon):
+        from pymacaroons.macaroon import MACAROON_V2
+
+        # https://github.com/rescrv/libmacaroons/blob/master/doc/format.txt
+        data = bytearray()
+        data.append(MACAROON_V2)
+        if macaroon.location is not None:
+            _append_packet(data, _LOCATION, convert_to_bytes(
+                macaroon.location))
+        _append_packet(data, _IDENTIFIER, macaroon.identifier)
+        _append_packet(data, _EOS)
+        for c in macaroon.caveats:
+            if c.location is not None:
+                _append_packet(data, _LOCATION,
+                               convert_to_bytes(c.location))
+            _append_packet(data, _IDENTIFIER, convert_to_bytes(c.caveat_id))
+            if c.verification_key_id is not None:
+                _append_packet(data, _VID, convert_to_bytes(
+                    c.verification_key_id))
+            _append_packet(data, _EOS)
+        _append_packet(data, _EOS)
+        _append_packet(data, _SIGNATURE, binascii.unhexlify(
+            macaroon.signature_bytes))
+        return bytes(data)
 
     def deserialize(self, serialized):
-        from pymacaroons.macaroon import Macaroon
+        if len(serialized) == 0:
+            raise ValueError('empty macaroon')
+        serialized = convert_to_string(serialized)
+        decoded = raw_b64decode(serialized)
+        return self.deserialize_raw(decoded)
+
+    def deserialize_raw(self, serialized):
+        from pymacaroons.macaroon import MACAROON_V2
+        from pymacaroons.exceptions import MacaroonDeserializationException
+
+        first = six.byte2int(serialized[:1])
+        if first == MACAROON_V2:
+            return self._deserialize_v2(serialized)
+        if _is_ascii_hex(first):
+            return self._deserialize_v1(serialized)
+        raise MacaroonDeserializationException(
+            'cannot determine data format of binary-encoded macaroon')
+
+    def _deserialize_v1(self, decoded):
+        from pymacaroons.macaroon import Macaroon, MACAROON_V1
         from pymacaroons.caveat import Caveat
         from pymacaroons.exceptions import MacaroonDeserializationException
 
-        macaroon = Macaroon()
-
-        decoded = urlsafe_b64decode(convert_to_bytes(
-            serialized + "=" * (-len(serialized) % 4)
-        ))
+        macaroon = Macaroon(version=MACAROON_V1)
 
         index = 0
 
@@ -82,6 +147,65 @@ class BinarySerializer(BaseSerializer):
 
         return macaroon
 
+    def _deserialize_v2(self, serialized):
+        from pymacaroons.macaroon import Macaroon, MACAROON_V2
+        from pymacaroons.caveat import Caveat
+        from pymacaroons.exceptions import MacaroonDeserializationException
+
+        # skip the initial version byte.
+        serialized = serialized[1:]
+        serialized, section = _parse_section_v2(serialized)
+        loc = ''
+        if len(section) > 0 and section[0].field_type == _LOCATION:
+            loc = section[0].data.decode('utf-8')
+            section = section[1:]
+        if len(section) != 1 or section[0].field_type != _IDENTIFIER:
+            raise MacaroonDeserializationException('invalid macaroon header')
+        macaroon = Macaroon(
+            identifier=section[0].data,
+            location=loc,
+            version=MACAROON_V2,
+        )
+        while True:
+            rest, section = _parse_section_v2(serialized)
+            serialized = rest
+            if len(section) == 0:
+                break
+            cav = Caveat()
+            if len(section) > 0 and section[0].field_type == _LOCATION:
+                cav.location = section[0].data.decode('utf-8')
+                section = section[1:]
+
+            if len(section) == 0 or section[0].field_type != _IDENTIFIER:
+                raise MacaroonDeserializationException(
+                    'no identifier in caveat')
+
+            cav.caveat_id = section[0].data
+            section = section[1:]
+            if len(section) == 0:
+                # First party caveat.
+                if cav.location is not None:
+                    raise MacaroonDeserializationException(
+                        'location not allowed in first party caveat')
+                macaroon.caveats.append(cav)
+                continue
+
+            if len(section) != 1:
+                raise MacaroonDeserializationException(
+                    'extra fields found in caveat')
+
+            if section[0].field_type != _VID:
+                raise MacaroonDeserializationException(
+                    'invalid field found in caveat')
+            cav.verification_key_id = section[0].data
+            macaroon.caveats.append(cav)
+        serialized, packet = _parse_packet_v2(serialized)
+        if packet.field_type != _SIGNATURE:
+            raise MacaroonDeserializationException(
+                'unexpected field found instead of signature')
+        macaroon.signature = binascii.hexlify(packet.data)
+        return macaroon
+
     def _packetize(self, key, data):
         # The 2 covers the space and the newline
         packet_size = self.PACKET_PREFIX_LENGTH + 2 + len(key) + len(data)
@@ -113,3 +237,120 @@ class BinarySerializer(BaseSerializer):
         key = packet.split(b' ')[0]
         value = packet[len(key) + 1:-1]
         return (key, value)
+
+
+def _append_packet(data, field_type, packet_data=None):
+    _encode_uvarint(data, field_type)
+    if field_type != _EOS:
+        _encode_uvarint(data, len(packet_data))
+        data.extend(packet_data)
+
+
+def _parse_section_v2(data):
+    ''' Parses a sequence of packets in data.
+
+    The sequence is terminated by a packet with a field type of EOS
+    :param data bytes to be deserialized.
+    :return: the rest of data and an array of packet V2
+    '''
+
+    from pymacaroons.exceptions import MacaroonDeserializationException
+
+    prev_field_type = -1
+    packets = []
+    while True:
+        if len(data) == 0:
+            raise MacaroonDeserializationException(
+                'section extends past end of buffer')
+        rest, packet = _parse_packet_v2(data)
+        if packet.field_type == _EOS:
+            return rest, packets
+        if packet.field_type <= prev_field_type:
+            raise MacaroonDeserializationException('fields out of order')
+        packets.append(packet)
+        prev_field_type = packet.field_type
+        data = rest
+
+
+def _parse_packet_v2(data):
+    ''' Parses a V2 data packet at the start of the given data.
+
+    The format of a packet is as follows:
+
+    field_type(varint) payload_len(varint) data[payload_len bytes]
+
+    apart from EOS which has no payload_en or data (it's a single zero byte).
+
+    :param data:
+    :return: rest of data, PacketV2
+    '''
+    from pymacaroons.exceptions import MacaroonDeserializationException
+
+    ft, n = _decode_uvarint(data)
+    data = data[n:]
+    if ft == _EOS:
+        return data, PacketV2(ft, None)
+    payload_len, n = _decode_uvarint(data)
+    data = data[n:]
+    if payload_len > len(data):
+        raise MacaroonDeserializationException(
+            'field data extends past end of buffer')
+    return data[payload_len:], PacketV2(ft, data[0:payload_len])
+
+
+def _encode_uvarint(data, n):
+    ''' Encodes integer into variable-length format into data.'''
+    if n < 0:
+        raise ValueError('only support positive integer')
+    while True:
+        this_byte = n & 0x7f
+        n >>= 7
+        if n == 0:
+            data.append(this_byte)
+            break
+        data.append(this_byte | 0x80)
+
+
+if sys.version_info.major == 2:
+    def _decode_uvarint(data):
+        ''' Decode a variable -length integer.
+
+        Reads a sequence of unsigned integer byte and decodes them into an
+        integer in variable-length format and returns it and the length read.
+        '''
+        n = 0
+        shift = 0
+        i = 0
+        for b in data:
+            b = ord(b)
+            i += 1
+            if b < 0x80:
+                return n | b << shift, i
+            n |= (b & 0x7f) << shift
+            shift += 7
+        raise Exception('cannot read uvarint from buffer')
+else:
+    def _decode_uvarint(data):
+        ''' Decode a variable -length integer.
+
+        Reads a sequence of unsigned integer byte and decodes them into an
+        integer in variable-length format and returns it and the length read.
+        '''
+        n = 0
+        shift = 0
+        i = 0
+        for b in data:
+            i += 1
+            if b < 0x80:
+                return n | b << shift, i
+            n |= (b & 0x7f) << shift
+            shift += 7
+        raise Exception('cannot read uvarint from buffer')
+
+
+def _is_ascii_hex(b):
+    if ord('0') <= b <= ord('9'):
+        return True
+    if ord('a') <= b <= ord('f'):
+        return True
+    return False

--- a/pymacaroons/serializers/json_serializer.py
+++ b/pymacaroons/serializers/json_serializer.py
@@ -42,7 +42,7 @@ class JsonSerializer(object):
         @return JSON macaroon in v2 format.
         '''
         serialized = {}
-        _add_json_binary_field(macaroon.identifier, serialized, 'i')
+        _add_json_binary_field(macaroon.identifier_bytes, serialized, 'i')
         _add_json_binary_field(binascii.unhexlify(macaroon.signature_bytes),
                                serialized, 's')
 
@@ -85,7 +85,8 @@ class JsonSerializer(object):
                 ),
                 location=(
                     c['cl'] if c.get('cl') else None
-                )
+                ),
+                version=MACAROON_V1
             )
             caveats.append(caveat)
 
@@ -110,7 +111,8 @@ class JsonSerializer(object):
             caveat = Caveat(
                 caveat_id=_read_json_binary_field(c, 'i'),
                 verification_key_id=_read_json_binary_field(c, 'v'),
-                location=_read_json_binary_field(c, 'l')
+                location=_read_json_binary_field(c, 'l'),
+                version=MACAROON_V2
             )
             caveats.append(caveat)
         return Macaroon(
@@ -129,7 +131,7 @@ def _caveat_v1_to_dict(c):
     '''
     serialized = {}
     if len(c.caveat_id) > 0:
-        serialized['cid'] = utils.convert_to_string(c.caveat_id)
+        serialized['cid'] = c.caveat_id
     if c.verification_key_id:
         serialized['vid'] = utils.raw_urlsafe_b64encode(
             c.verification_key_id).decode('utf-8')
@@ -143,8 +145,8 @@ def _caveat_v2_to_dict(c):
     macaroon v2 format.
     '''
     serialized = {}
-    if len(c.caveat_id) > 0:
-        _add_json_binary_field(c.caveat_id, serialized, 'i')
+    if len(c.caveat_id_bytes) > 0:
+        _add_json_binary_field(c.caveat_id_bytes, serialized, 'i')
     if c.verification_key_id:
         _add_json_binary_field(c.verification_key_id, serialized, 'v')
     if c.location:

--- a/pymacaroons/serializers/json_serializer.py
+++ b/pymacaroons/serializers/json_serializer.py
@@ -1,39 +1,179 @@
+import binascii
 import json
-from base64 import standard_b64decode
-from pymacaroons.utils import convert_to_string
+from pymacaroons import utils
 
 
 class JsonSerializer(object):
+    '''Serializer used to produce JSON macaroon format v1.
+    '''
+    def serialize(self, m):
+        '''Serialize the macaroon in JSON format indicated by the version field.
 
-    def serialize(self, macaroon):
+        @param macaroon the macaroon to serialize.
+        @return JSON macaroon.
+        '''
+        from pymacaroons import macaroon
+        if m.version == macaroon.MACAROON_V1:
+            return self._serialize_v1(m)
+        return self._serialize_v2(m)
+
+    def _serialize_v1(self, macaroon):
+        '''Serialize the macaroon in JSON format v1.
+
+        @param macaroon the macaroon to serialize.
+        @return JSON macaroon.
+        '''
         serialized = {
-            'location': macaroon.location,
-            'identifier': macaroon.identifier,
-            'caveats': [caveat.to_dict() for caveat in macaroon.caveats],
-            'signature': macaroon.signature
+            'identifier': utils.convert_to_string(macaroon.identifier),
+            'signature': macaroon.signature,
         }
+        if macaroon.location:
+            serialized['location'] = macaroon.location
+        if macaroon.caveats:
+            serialized['caveats'] = [
+                _caveat_v1_to_dict(caveat) for caveat in macaroon.caveats
+            ]
+        return json.dumps(serialized)
+
+    def _serialize_v2(self, macaroon):
+        '''Serialize the macaroon in JSON format v2.
+
+        @param macaroon the macaroon to serialize.
+        @return JSON macaroon in v2 format.
+        '''
+        serialized = {}
+        _add_json_binary_field(macaroon.identifier, serialized, 'i')
+        _add_json_binary_field(binascii.unhexlify(macaroon.signature_bytes),
+                               serialized, 's')
+
+        if macaroon.location:
+            serialized['l'] = macaroon.location
+        if macaroon.caveats:
+            serialized['c'] = [
+                _caveat_v2_to_dict(caveat) for caveat in macaroon.caveats
+            ]
         return json.dumps(serialized)
 
     def deserialize(self, serialized):
-        from pymacaroons.macaroon import Macaroon
+        '''Deserialize a JSON macaroon depending on the format.
+
+        @param serialized the macaroon in JSON format.
+        @return the macaroon object.
+        '''
+        deserialized = json.loads(serialized)
+        if deserialized.get('identifier') is None:
+            return self._deserialize_v2(deserialized)
+        else:
+            return self._deserialize_v1(deserialized)
+
+    def _deserialize_v1(self, deserialized):
+        '''Deserialize a JSON macaroon in v1 format.
+
+        @param serialized the macaroon in v1 JSON format.
+        @return the macaroon object.
+        '''
+        from pymacaroons.macaroon import Macaroon, MACAROON_V1
         from pymacaroons.caveat import Caveat
 
         caveats = []
-        deserialized = json.loads(convert_to_string(serialized))
-
-        for c in deserialized['caveats']:
+        for c in deserialized.get('caveats', []):
             caveat = Caveat(
                 caveat_id=c['cid'],
                 verification_key_id=(
-                    standard_b64decode(c['vid']) if c['vid'] else None
+                    utils.raw_b64decode(c['vid']) if c.get('vid')
+                    else None
                 ),
-                location=c['cl']
+                location=(
+                    c['cl'] if c.get('cl') else None
+                )
             )
             caveats.append(caveat)
 
         return Macaroon(
-            location=deserialized['location'],
+            location=deserialized.get('location'),
             identifier=deserialized['identifier'],
             caveats=caveats,
-            signature=deserialized['signature']
+            signature=deserialized['signature'],
+            version=MACAROON_V1
         )
+
+    def _deserialize_v2(self, deserialized):
+        '''Deserialize a JSON macaroon v2.
+
+        @param serialized the macaroon in JSON format v2.
+        @return the macaroon object.
+        '''
+        from pymacaroons.macaroon import Macaroon, MACAROON_V2
+        from pymacaroons.caveat import Caveat
+        caveats = []
+        for c in deserialized.get('c', []):
+            caveat = Caveat(
+                caveat_id=_read_json_binary_field(c, 'i'),
+                verification_key_id=_read_json_binary_field(c, 'v'),
+                location=_read_json_binary_field(c, 'l')
+            )
+            caveats.append(caveat)
+        return Macaroon(
+            location=_read_json_binary_field(deserialized, 'l'),
+            identifier=_read_json_binary_field(deserialized, 'i'),
+            caveats=caveats,
+            signature=binascii.hexlify(
+                _read_json_binary_field(deserialized, 's')),
+            version=MACAROON_V2
+        )
+
+
+def _caveat_v1_to_dict(c):
+    ''' Return a caveat as a dictionary for export as the JSON
+    macaroon v1 format.
+    '''
+    serialized = {}
+    if len(c.caveat_id) > 0:
+        serialized['cid'] = utils.convert_to_string(c.caveat_id)
+    if c.verification_key_id:
+        serialized['vid'] = utils.raw_urlsafe_b64encode(
+            c.verification_key_id).decode('utf-8')
+    if c.location:
+        serialized['cl'] = c.location
+    return serialized
+
+
+def _caveat_v2_to_dict(c):
+    ''' Return a caveat as a dictionary for export as the JSON
+    macaroon v2 format.
+    '''
+    serialized = {}
+    if len(c.caveat_id) > 0:
+        _add_json_binary_field(c.caveat_id, serialized, 'i')
+    if c.verification_key_id:
+        _add_json_binary_field(c.verification_key_id, serialized, 'v')
+    if c.location:
+        serialized['l'] = c.location
+    return serialized
+
+
+def _add_json_binary_field(b, serialized, field):
+    ''' Set the given field to the given val (a bytearray) in the serialized
+    dictionary.
+
+    If the value isn't valid utf-8, we base64 encode it and use field+"64"
+    as the field name.
+    '''
+    try:
+        val = b.decode("utf-8")
+        serialized[field] = val
+    except UnicodeDecodeError:
+        val = utils.raw_urlsafe_b64encode(b).decode('utf-8')
+        serialized[field + '64'] = val
+
+
+def _read_json_binary_field(deserialized, field):
+    ''' Read the value of a JSON field that may be string or base64-encoded.
+    '''
+    val = deserialized.get(field)
+    if val is not None:
+        return utils.convert_to_bytes(val)
+    val = deserialized.get(field + '64')
+    if val is None:
+        return None
+    return utils.raw_urlsafe_b64decode(val)

--- a/pymacaroons/utils.py
+++ b/pymacaroons/utils.py
@@ -1,3 +1,4 @@
+import base64
 from hashlib import sha256
 import hmac
 import binascii
@@ -9,7 +10,7 @@ def convert_to_bytes(string_or_bytes):
     if string_or_bytes is None:
         return None
     if isinstance(string_or_bytes, text_type):
-        return string_or_bytes.encode('ascii')
+        return string_or_bytes.encode('utf-8')
     elif isinstance(string_or_bytes, binary_type):
         return string_or_bytes
     else:
@@ -22,7 +23,7 @@ def convert_to_string(string_or_bytes):
     if isinstance(string_or_bytes, text_type):
         return string_or_bytes
     elif isinstance(string_or_bytes, binary_type):
-        return string_or_bytes.decode('ascii')
+        return string_or_bytes.decode('utf-8')
     else:
         raise TypeError("Must be a string or bytes object.")
 
@@ -92,3 +93,39 @@ def equals(val1, val2):
     for x, y in zip(val1, val2):
         result |= ord(x) ^ ord(y)
     return result == 0
+
+
+def add_base64_padding(b):
+    '''Add padding to base64 encoded bytes.
+
+    Padding can be removed when sending the messages.
+
+    @param b bytes to be padded.
+    @return a padded bytes.
+    '''
+    return b + b'=' * (-len(b) % 4)
+
+
+def raw_b64decode(s):
+    if '_' or '-' in s:
+        return raw_urlsafe_b64decode(s)
+    else:
+        return base64.b64decode(add_base64_padding(s))
+
+
+def raw_urlsafe_b64decode(s):
+    '''Base64 decode with added padding and conversion to bytes.
+
+    @param s string decode
+    @return bytes decoded
+    '''
+    return base64.urlsafe_b64decode(add_base64_padding(s.encode('utf-8')))
+
+
+def raw_urlsafe_b64encode(b):
+    '''Base64 encode with padding removed.
+
+    @param s string decode
+    @return bytes decoded
+    '''
+    return base64.urlsafe_b64encode(b).rstrip(b'=')

--- a/pymacaroons/verifier.py
+++ b/pymacaroons/verifier.py
@@ -57,7 +57,7 @@ class Verifier(object):
 
     def verify_discharge(self, root, discharge, key, discharge_macaroons=None):
         calculated_signature = hmac_digest(
-            key, discharge._identifier
+            key, discharge.identifier
         )
 
         calculated_signature = self._verify_caveats(
@@ -72,7 +72,7 @@ class Verifier(object):
             )
 
         if not self._signatures_match(
-                discharge.signature,
+                discharge.signature_bytes,
                 binascii.hexlify(calculated_signature)):
             raise MacaroonInvalidSignatureException('Signatures do not match.')
 
@@ -119,6 +119,6 @@ class Verifier(object):
 
     def _signatures_match(self, macaroon_signature, computed_signature):
         return constant_time_compare(
-            convert_to_string(macaroon_signature),
-            convert_to_string(computed_signature)
+            convert_to_bytes(macaroon_signature),
+            convert_to_bytes(computed_signature)
         )

--- a/pymacaroons/verifier.py
+++ b/pymacaroons/verifier.py
@@ -57,7 +57,7 @@ class Verifier(object):
 
     def verify_discharge(self, root, discharge, key, discharge_macaroons=None):
         calculated_signature = hmac_digest(
-            key, discharge.identifier
+            key, discharge.identifier_bytes
         )
 
         calculated_signature = self._verify_caveats(

--- a/tests/functional_tests/functional_tests.py
+++ b/tests/functional_tests/functional_tests.py
@@ -55,10 +55,9 @@ K8zMyhluSZuJtSTvdZopmDkTYjOGpmMI9vWcK'
         )
 
     def test_serializing_with_binary_v1(self):
-        identifier = base64.b64decode(u'AK2o+q0Aq9+bONkXw7ky7HAuhCLO9hhaMMc==')
         m = Macaroon(
             location='http://mybank/',
-            identifier=identifier,
+            identifier='we used our secret key',
             key='this is our super secret key; only we should know it',
             version=MACAROON_V1
         )
@@ -77,7 +76,7 @@ K8zMyhluSZuJtSTvdZopmDkTYjOGpmMI9vWcK'
         )
         m.add_first_party_caveat('test = caveat')
         n = Macaroon.deserialize(m.serialize())
-        assert_equal(m.identifier, n.identifier)
+        assert_equal(m.identifier_bytes, n.identifier_bytes)
         assert_equal(m.version, n.version)
 
     def test_serializing_v1(self):
@@ -101,8 +100,12 @@ K8zMyhluSZuJtSTvdZopmDkTYjOGpmMI9vWcK'
         )
         m.add_first_party_caveat('test = caveat')
         n = Macaroon.deserialize(m.serialize())
-        assert_equal(m.identifier, n.identifier)
+        assert_equal(m.identifier_bytes, n.identifier_bytes)
         assert_equal(m.version, n.version)
+
+    def test_deserializing_invalid(self):
+        with assert_raises(MacaroonDeserializationException) as cm:
+            Macaroon.deserialize("QA")
 
     def test_serializing_strips_padding(self):
         m = Macaroon(
@@ -200,7 +203,7 @@ cmUgGXusegRK8zMyhluSZuJtSTvdZopmDkTYjOGpmMI9vWcK'.encode('ascii')
             m.serialize(serializer=JsonSerializer()),
             serializer=JsonSerializer()
         )
-        assert_equal(m.identifier, n.identifier)
+        assert_equal(m.identifier_bytes, n.identifier_bytes)
 
     def test_serializing_json_v2(self):
         m = Macaroon(

--- a/tests/functional_tests/serialization_tests.py
+++ b/tests/functional_tests/serialization_tests.py
@@ -1,0 +1,79 @@
+from nose.tools import *
+from pymacaroons import Macaroon, Verifier, MACAROON_V1, MACAROON_V2
+from pymacaroons.serializers import JsonSerializer
+
+
+class TestSerializationCompatibility(object):
+
+    def setup(self):
+        pass
+
+    def test_from_go_macaroon_json_v2(self):
+        # The following macaroon have been generated with
+        # https://github.com/go-macaroon/macaroon
+        # to test the deserialization.
+        json_v1 = '{"caveats":[{"cid":"fp caveat"},{"cid":"tp caveat",' \
+                  '"vid":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAp_MgxHrfLnfvNuYDo' \
+                  'zNKWTlRPPx6VemasWnPpJdAWE6FWmOuFX4sB4-a1oAURDp",' \
+                  '"cl":"tp location"}],"location":"my location",' \
+                  '"identifier":"my identifier",' \
+                  '"signature":"483b3881c9990e5099cb6695da3164daa64da60417b' \
+                  'caf9e9dc4c0a9968f6636"}'
+        json_v1_discharge = '{"caveats":[],"location":"tp location",' \
+                            '"identifier":"tp caveat",' \
+                            '"signature":"8506007f69ae3e6a654e0b9769f20dd9da5' \
+                            'd2af7860070d6776c15989fb7dea6"}'
+        m = Macaroon.deserialize(json_v1, serializer=JsonSerializer())
+        discharge = Macaroon.deserialize(json_v1_discharge,
+                                         serializer=JsonSerializer())
+        assert_macaroon(m, discharge, MACAROON_V1)
+
+        binary_v1 = 'MDAxOWxvY2F0aW9uIG15IGxvY2F0aW9uCjAwMWRpZGVudGlmaWVyIG1' \
+                    '5IGlkZW50aWZpZXIKMDAxMmNpZCBmcCBjYXZlYXQKMDAxMmNpZCB0cC' \
+                    'BjYXZlYXQKMDA1MXZpZCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACn' \
+                    '8yDEet8ud+825gOjM0pZOVE8/HpV6Zqxac+kl0BYToVaY64VfiwHj5r' \
+                    'WgBREOkKMDAxM2NsIHRwIGxvY2F0aW9uCjAwMmZzaWduYXR1cmUgSDs' \
+                    '4gcmZDlCZy2aV2jFk2qZNpgQXvK+encTAqZaPZjYK'
+        binary_v1_discharge = 'MDAxOWxvY2F0aW9uIHRwIGxvY2F0aW9uCjAwMTlpZGVud' \
+                              'GlmaWVyIHRwIGNhdmVhdAowMDJmc2lnbmF0dXJlIIUGAH' \
+                              '9prj5qZU4Ll2nyDdnaXSr3hgBw1ndsFZift96mCg'
+        m = Macaroon.deserialize(binary_v1)
+        discharge = Macaroon.deserialize(binary_v1_discharge)
+        assert_macaroon(m, discharge, MACAROON_V1)
+
+        json_v2 = '{"c":[{"i":"fp caveat"},{"i":"tp caveat",' \
+                  '"v64":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAp_MgxHrfLnfvNuYDoz' \
+                  'NKWTlRPPx6VemasWnPpJdAWE6FWmOuFX4sB4-a1oAURDp",' \
+                  '"l":"tp location"}],"l":"my location","i":"my identifier",' \
+                  '"s64":"SDs4gcmZDlCZy2aV2jFk2qZNpgQXvK-encTAqZaPZjY"}'
+        json_v2_discharge = '{"l":"tp location","i":"tp caveat","s64":"hQYAf2' \
+                            'muPmplTguXafIN2dpdKveGAHDWd2wVmJ-33qY"}'
+        m = Macaroon.deserialize(json_v2, serializer=JsonSerializer())
+        discharge = Macaroon.deserialize(json_v2_discharge,
+                                         serializer=JsonSerializer())
+        assert_macaroon(m, discharge, MACAROON_V2)
+
+        binary_v2 = 'AgELbXkgbG9jYXRpb24CDW15IGlkZW50aWZpZXIAAglmcCBjYXZlYXQ' \
+                    'AAQt0cCBsb2NhdGlvbgIJdHAgY2F2ZWF0BEgAAAAAAAAAAAAAAAAAAA' \
+                    'AAAAAAAAAAAAACn8yDEet8ud+825gOjM0pZOVE8/HpV6Zqxac+kl0BY' \
+                    'ToVaY64VfiwHj5rWgBREOkAAAYgSDs4gcmZDlCZy2aV2jFk2qZNpgQX' \
+                    'vK+encTAqZaPZjY'
+        binary_v2_discharge = 'AgELdHAgbG9jYXRpb24CCXRwIGNhdmVhdAAABiCFBgB/a' \
+                              'a4+amVOC5dp8g3Z2l0q94YAcNZ3bBWYn7fepg'
+        m = Macaroon.deserialize(binary_v2)
+        discharge = Macaroon.deserialize(binary_v2_discharge)
+        assert_macaroon(m, discharge, MACAROON_V2)
+
+
+def assert_macaroon(m, discharge, version):
+    assert_equal(m.location, 'my location')
+    assert_equal(m.version, version)
+    assert_equal(m.identifier, b'my identifier')
+    v = Verifier()
+    v.satisfy_exact('fp caveat')
+    verified = v.verify(
+        m,
+        "my secret key",
+        discharge_macaroons=[discharge],
+    )
+    assert_true(verified)

--- a/tests/functional_tests/serialization_tests.py
+++ b/tests/functional_tests/serialization_tests.py
@@ -68,7 +68,7 @@ class TestSerializationCompatibility(object):
 def assert_macaroon(m, discharge, version):
     assert_equal(m.location, 'my location')
     assert_equal(m.version, version)
-    assert_equal(m.identifier, b'my identifier')
+    assert_equal(m.identifier_bytes, b'my identifier')
     v = Verifier()
     v.satisfy_exact('fp caveat')
     verified = v.verify(

--- a/tests/property_tests/macaroon_property_tests.py
+++ b/tests/property_tests/macaroon_property_tests.py
@@ -46,6 +46,6 @@ class TestMacaroon(object):
             version=MACAROON_V2
         )
         deserialized = Macaroon.deserialize(macaroon.serialize())
-        assert_equal(macaroon.identifier, deserialized.identifier)
+        assert_equal(macaroon.identifier_bytes, deserialized.identifier_bytes)
         assert_equal(macaroon.location, deserialized.location)
         assert_equal(macaroon.signature, deserialized.signature)

--- a/tests/property_tests/macaroon_property_tests.py
+++ b/tests/property_tests/macaroon_property_tests.py
@@ -1,12 +1,10 @@
 from __future__ import unicode_literals
 
-from mock import *
 from nose.tools import *
 from hypothesis import *
 from hypothesis.specifiers import *
 
-from six import text_type, binary_type
-from pymacaroons import Macaroon, Verifier
+from pymacaroons import Macaroon, MACAROON_V1, MACAROON_V2
 from pymacaroons.utils import convert_to_bytes
 
 
@@ -34,7 +32,18 @@ class TestMacaroon(object):
         macaroon = Macaroon(
             location=loc,
             identifier=key_id,
-            key=key
+            key=key,
+            version=MACAROON_V1
+        )
+        deserialized = Macaroon.deserialize(macaroon.serialize())
+        assert_equal(macaroon.identifier, deserialized.identifier)
+        assert_equal(macaroon.location, deserialized.location)
+        assert_equal(macaroon.signature, deserialized.signature)
+        macaroon = Macaroon(
+            location=loc,
+            identifier=key_id,
+            key=key,
+            version=MACAROON_V2
         )
         deserialized = Macaroon.deserialize(macaroon.serialize())
         assert_equal(macaroon.identifier, deserialized.identifier)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, pypy, pypy3, flake8, docs
+envlist = py26, py27, py33, py34, py35, pypy, pypy3, flake8, docs
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
See for dicsussion https://groups.google.com/forum/#!topic/macaroons/EIDUZQoelq8
and https://github.com/ecordell/pymacaroons/issues/22.

The main non backward compatible changes are in the Macaroon and Caveat object.
Identifier is now a bytes.