### PR TITLE
Convert to pynacl instead of libnacl

### DIFF
--- a/pymacaroons/caveat_delegates/third_party.py
+++ b/pymacaroons/caveat_delegates/third_party.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 import binascii
 
-from libnacl.secret import SecretBox
+from nacl.secret import SecretBox
 
 from pymacaroons import Caveat
 from pymacaroons.utils import (

--- a/pymacaroons/field_encryptors/secret_box_encryptor.py
+++ b/pymacaroons/field_encryptors/secret_box_encryptor.py
@@ -1,6 +1,6 @@
 from base64 import standard_b64encode, standard_b64decode
 
-from libnacl.secret import SecretBox
+from nacl.secret import SecretBox
 
 from pymacaroons.field_encryptors.base_field_encryptor import (
     BaseFieldEncryptor

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     install_requires=[
         'six>=1.8.0',
-        'libnacl>=1.3.6,<1.6',
+        'PyNaCl>=1.1.2,<2.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/functional_tests/encrypted_field_tests.py
+++ b/tests/functional_tests/encrypted_field_tests.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from nose.tools import *
 
-from libnacl import crypto_box_NONCEBYTES
+from nacl.bindings import crypto_box_NONCEBYTES
 from pymacaroons import Macaroon, Verifier
 from pymacaroons.caveat_delegates import EncryptedFirstPartyCaveatDelegate, EncryptedFirstPartyCaveatVerifierDelegate
 from pymacaroons.field_encryptors import SecretBoxEncryptor

--- a/tests/functional_tests/functional_tests.py
+++ b/tests/functional_tests/functional_tests.py
@@ -4,7 +4,7 @@ import json
 from mock import *
 from nose.tools import *
 
-from libnacl import crypto_box_NONCEBYTES
+from nacl.bindings import crypto_box_NONCEBYTES
 from pymacaroons import Macaroon, MACAROON_V1, MACAROON_V2, Verifier
 from pymacaroons.serializers import *
 from pymacaroons.exceptions import *
@@ -296,7 +296,7 @@ key", "signature": "197bac7a044af33332865b9266e26d493bdd668a660e44d88ce1a998c2\
         )
         assert_true(verified)
 
-    @patch('libnacl.secret.libnacl.utils.rand_nonce')
+    @patch('nacl.secret.random')
     def test_third_party_caveat(self, rand_nonce):
         # use a fixed nonce to ensure the same signature
         rand_nonce.return_value = truncate_or_pad(
@@ -344,7 +344,7 @@ never use the same secret twice',
             n.signature
         )
 
-    @patch('libnacl.secret.libnacl.utils.rand_nonce')
+    @patch('nacl.secret.random')
     def test_prepare_for_request(self, rand_nonce):
         # use a fixed nonce to ensure the same signature
         rand_nonce.return_value = truncate_or_pad(
@@ -428,7 +428,7 @@ never use the same secret twice',
       verified = Verifier().verify(root, "root-key", [discharge1, discharge2])
       assert_true(verified)
 
-    @patch('libnacl.secret.libnacl.utils.rand_nonce')
+    @patch('nacl.secret.random')
     def test_inspect(self, rand_nonce):
         # use a fixed nonce to ensure the same signature
         rand_nonce.return_value = truncate_or_pad(


### PR DESCRIPTION
This brings pymacaroons in line with py-macaroon-bakery on which binding library it uses.  This fixes ReadTheDocs builds of libraries that depend on this (e.g., python-libjuju) due to RTD builders not having
`libsodium.so` available (pynacl seems to have support to build the headers it needs during installation).

Fixes #44
Fixes go-macaroon-bakery/py-macaroon-bakery#47